### PR TITLE
NO-TICKET: Upgrade Go version 1.24

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -31,7 +31,7 @@ jobs:
     steps:          
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache: false
 
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     steps:  
         - uses: actions/setup-go@v4
           with:
-            go-version: '1.22'
+            go-version: '1.24'
             cache: false
 
         - uses: actions/checkout@v4


### PR DESCRIPTION
# Force Go CI to use latest Go version

As Go only supports the latest 2 versions of its language, the Go version `1.22` is now unsupported.

## Golang Supported Versions Policy

https://go.dev/doc/devel/release#policy

## Impact

This will force any GitHub Repository using Go CI to use Go version `1.24`.

This will break flows unless the individual using this action upgrades the Repository to the latest version of Go.

## Repository Go Upgrade Example

Example of upgrade with Core API: https://github.com/12traits/core-api/commit/15517968fd18a200b7cfee88e53a8c7d94ea3f47