### PR TITLE
Harden github-release semver parsing against shell injection

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -19,10 +19,14 @@ jobs:
       - name: Retrieve semver from release branch
         shell: bash
         id: vars-step
+        # Pass the commit message via env, never inline ${{ }} into the script:
+        # raw interpolation lets backticks/parens/quotes in a message run as shell.
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          cd $GITHUB_WORKSPACE
-          export SEMVER=`echo "${{ github.event.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
-          echo "semver=$SEMVER" >> $GITHUB_OUTPUT
+          cd "$GITHUB_WORKSPACE"
+          SEMVER=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | grep -i "release-" | cut -d '-' -f 2 | head -n 1)
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.gh-token }}"


### PR DESCRIPTION
## Problem

`github-release.yml` interpolated `${{ github.event.head_commit.message }}` directly into a bash `run:` block:

```bash
export SEMVER=`echo "${{ github.event.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
```

Any commit/release message containing backticks, parentheses, or quotes is parsed as shell. This just failed `clustering`'s `release-1.9.9` deploy (run 28177192691) because the aggregated release message embedded a PR body with backticks:

```
installs: command not found
syntax error near unexpected token `[dev],'
```

It is also a script-injection vector (arbitrary commands from a commit message run on the self-hosted runner).

## Fix

Pass the message via `env:` and reference it quoted; use `$(...)` instead of backticks. Parsing semantics are unchanged — verified it still extracts `1.9.9` from the message that broke the job.

```yaml
env:
  HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
run: |
  SEMVER=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | grep -i "release-" | cut -d '-' -f 2 | head -n 1)
```

## After merge

Re-run the failed `clustering` deploy-prod run so `release-1.9.9` ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)