### PR TITLE
fix: robust semver extraction from merge commit message

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -25,7 +25,11 @@ jobs:
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cd "$GITHUB_WORKSPACE"
-          SEMVER=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | grep -i "release-" | cut -d '-' -f 2 | head -n 1)
+          # Extract just the semver after "release-", ignoring any trailing text
+          # such as the "(#1234)" GitHub appends to PR-title-style merge commits.
+          # Handles both "Merge pull request #N from org/release-X.Y.Z" and
+          # "release-X.Y.Z (#N)".
+          SEMVER=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | grep -oiE 'release-[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | cut -d '-' -f 2)
           echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:


### PR DESCRIPTION
## Problem
The release tag is derived from the HEAD commit message:
```bash
SEMVER=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | grep -i "release-" | cut -d '-' -f 2 | head -n 1)
```
`cut -d'-' -f2` returns **everything after the first hyphen**, so it only works when the version is the last token. Modern GitHub merge commits use the PR-title format `release-X.Y.Z (#NNNN)`, which yields `X.Y.Z (#NNNN)` → an **invalid git tag** (`refs/tags/3.8.2 (#1083)` is not a valid ref name) → the `github-release` job fails and all downstream deploy jobs are skipped.

This bit the `chat` repo's prod releases 3.8.1 and 3.8.2 (both failed at the tag step). The parser has been fragile since 2023; it only worked because older merges happened to put the version last (`Merge pull request #N from org/release-X.Y.Z`).

## Fix
Extract the `release-X.Y.Z` token with a regex and ignore any trailing text:
```bash
SEMVER=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | grep -oiE 'release-[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | cut -d '-' -f 2)
```

Backward compatible — handles both message formats:

| HEAD commit message | extracted semver |
|---|---|
| `Merge pull request #1074 from 12traits/release-3.8.0` | `3.8.0` |
| `release-3.8.2 (#1083)` | `3.8.2` |
| `Merge pull request #1084 from 12traits/release-3.8.3` | `3.8.3` |

Keeps the existing env-var hardening (no `${{ }}` inlined into the script).

## Note
`@main` is referenced directly by consumer repos, so this takes effect for all of them on merge. Strictly more tolerant than the current behavior, so it should not break any repo currently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)